### PR TITLE
do not depend on the full PromiseKit, use minimal subspec instead

### DIFF
--- a/RestKit-PromiseKit.podspec
+++ b/RestKit-PromiseKit.podspec
@@ -35,6 +35,6 @@ EOS
   }
   s.source_files          = 'RestKit-PromiseKit'
   s.requires_arc          = true
-  s.dependency 'PromiseKit', '~> 1.5'
+  s.dependency 'PromiseKit/Promise', '~> 1.5'
   s.dependency 'RestKit', '~> 0.20'
 end


### PR DESCRIPTION
the full PromiseKit pod pulls in a lot of stuff that might not be needed in the end (e.g. OMGHTTPURLRQ), PromiseKit/Promise is enough here.
